### PR TITLE
Add value param to select2_from_ajax(_multiple)

### DIFF
--- a/resources/views/fields/select2_from_ajax.blade.php
+++ b/resources/views/fields/select2_from_ajax.blade.php
@@ -30,7 +30,7 @@
                 @endif
 
                 <option value="{{ $item->getKey() }}" selected>
-                    {{ $item->{$field['attribute']} }}
+                    {{ $item->{ $field['value'] ?? $field['attribute']} }}
                 </option>
             @endif
         @endif
@@ -113,7 +113,7 @@
                                 var result = {
                                     results: $.map(data.data, function (item) {
                                         return {
-                                            text: item["{{ $field['attribute'] }}"],
+                                            text: item["{{  $field['value'] ?? $field['attribute'] }}"],
                                             id: item["{{ $connected_entity_key_name }}"]
                                         }
                                     }),

--- a/resources/views/fields/select2_from_ajax_multiple.blade.php
+++ b/resources/views/fields/select2_from_ajax_multiple.blade.php
@@ -23,7 +23,7 @@
                     @endphp
                 @endif
                 <option value="{{ $item->getKey() }}" selected>
-                    {{ $item->{$field['attribute']} }}
+                    {{ $field['value'] ?? $item->{$field['attribute']} }}
                 </option>
             @endforeach
         @endif
@@ -92,7 +92,7 @@
                                 return {
                                     results: $.map(data.data, function (item) {
                                         return {
-                                            text: item["{{ $field['attribute'] }}"],
+                                            text: item["{{ $field['value'] ?? $field['attribute'] }}"],
                                             id: item["{{ $connected_entity_key_name }}"]
                                         }
                                     }),


### PR DESCRIPTION
Add `value` param to `select2_from_ajax(_multiple)` blade, in order to be able to display accessors in the dropdown list.