### PR TITLE
Fix option label in ajax select2 fields.

### DIFF
--- a/resources/views/fields/select2_from_ajax.blade.php
+++ b/resources/views/fields/select2_from_ajax.blade.php
@@ -30,7 +30,7 @@
                 @endif
 
                 <option value="{{ $item->getKey() }}" selected>
-                    {{ $item->{ $field['value'] ?? $field['attribute']} }}
+                    {{ $item->{isset($field['option_label']) ? $field['option_label'] : $field['attribute']} }}
                 </option>
             @endif
         @endif
@@ -113,7 +113,7 @@
                                 var result = {
                                     results: $.map(data.data, function (item) {
                                         return {
-                                            text: item["{{  $field['value'] ?? $field['attribute'] }}"],
+                                            text: item["{{ isset($field['option_label']) ? $field['option_label'] : $field['attribute'] }}"],
                                             id: item["{{ $connected_entity_key_name }}"]
                                         }
                                     }),

--- a/resources/views/fields/select2_from_ajax_multiple.blade.php
+++ b/resources/views/fields/select2_from_ajax_multiple.blade.php
@@ -23,7 +23,7 @@
                     @endphp
                 @endif
                 <option value="{{ $item->getKey() }}" selected>
-                    {{ $item->{$field['value'] ?? $field['attribute']} }}
+                    {{ $item->{isset($field['option_label']) ? $field['option_label'] : $field['attribute']} }}
                 </option>
             @endforeach
         @endif
@@ -92,7 +92,7 @@
                                 return {
                                     results: $.map(data.data, function (item) {
                                         return {
-                                            text: item["{{ $field['value'] ?? $field['attribute'] }}"],
+                                            text: item["{{ isset($field['option_label']) ? $field['option_label'] : $field['attribute'] }}"],
                                             id: item["{{ $connected_entity_key_name }}"]
                                         }
                                     }),


### PR DESCRIPTION
Fix option label in ajax select2 fields:
'value' key is already in use, change to 'option_label'.